### PR TITLE
Fix: misspelling of FastAsyncWorldEdit

### DIFF
--- a/sources/why-plotsquared.adoc
+++ b/sources/why-plotsquared.adoc
@@ -24,7 +24,7 @@
 == Safety
 
 * You can safely allow redstone, tnt without worrying about lag, griefing from sand cannons, pistons, tnt, ...
-* You have a reliable https://dev.bukkit.org/projects/worldedit[WorldEdit] / https://www.spigotmc.org/resources/fast-async-worldedit.13932[FasAsyncWorldEdit] restriction
+* You have a reliable https://dev.bukkit.org/projects/worldedit[WorldEdit] / https://www.spigotmc.org/resources/fast-async-worldedit.13932[FastAsyncWorldEdit] restriction
 * Chunk and WorldEdit processor to prevent lag, crashes and data corruption
 * Lots of redundancies. e.g. Backup your database with `/plot database`, or if you loose both, you can still recover based on plot sign information.
 


### PR DESCRIPTION
**Description**
<!--- Please describe what this pull request does. -->
I just added one single character from `FasAsyncWorldEdit` to `FastAsyncWorldEdit`.

**Submitter Checklist**
<!--- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the proposed change appropriately.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md)
